### PR TITLE
Add support for dynamic executors

### DIFF
--- a/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -22,7 +22,9 @@ import io.fabric8.kubernetes.api.model.PodBuilder
 import io.fabric8.kubernetes.api.model.extensions.JobBuilder
 import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
 import org.apache.spark.internal.config._
+import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster._
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.{SparkConf, SparkContext, SparkException}
 import org.apache.spark.rpc.RpcEndpointAddress
 import org.apache.spark.scheduler.TaskSchedulerImpl
@@ -42,8 +44,10 @@ private[spark] class KubernetesClusterSchedulerBackend(
   val DEFAULT_NUMBER_EXECUTORS = 2
   val sparkExecutorName = s"spark-executor-${Random.alphanumeric take 5 mkString("")}".toLowerCase()
 
+  // TODO: do these need mutex guarding?
   // key is executor id, value is pod name
-  var executorToPod = mutable.Map.empty[String, String]
+  var executorToPod = mutable.Map.empty[String, String] // active executors
+  var shutdownToPod = mutable.Map.empty[String, String] // pending shutdown
   var executorID = 0
 
   val sparkDriverImage = sc.getConf.get("spark.kubernetes.driver.image")
@@ -63,7 +67,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
   }
 
   override def stop(): Unit = {
+    // Kill all executor pods indiscriminately
     killExecutorPods(executorToPod.toVector)
+    killExecutorPods(shutdownToPod.toVector)
     super.stop()
   }
 
@@ -73,23 +79,28 @@ private[spark] class KubernetesClusterSchedulerBackend(
     val n = executorToPod.size
     val delta = requestedTotal - n
     if (delta > 0) {
-      logInfo(s"Adding $delta new executor Pods")
+      logInfo(s"Adding $delta new executors")
       createExecutorPods(delta)
     } else if (delta < 0) {
-      logInfo(s"Deleting ${-delta} new executor Pods")
-      // TODO: What is an informed way to kill executors with the least (or zero) load?
-      val kill = executorToPod.toVector.slice(n + delta, n)
-      killExecutorPods(kill)
+      val d = -delta
+      val idle = executorToPod.toVector.filter { case (id, _) => !scheduler.isExecutorBusy(id) }
+      if (idle.length > 0) {
+        logInfo(s"Shutting down ${idle.length} idle executors")
+        shutdownExecutors(idle.take(d))
+      }
+      val r = math.max(0, d - idle.length)
+      if (r > 0) {
+        logInfo(s"Shutting down $r non-idle executors")
+        shutdownExecutors(executorToPod.toVector.slice(n - r, n))
+      }
     }
     // TODO: are there meaningful failure modes here?
     Future.successful(true)
   }
 
   override def doKillExecutors(executorIds: Seq[String]): Future[Boolean] = {
-    logInfo(s"doKillExecutors")
+    logInfo(s"Received doKillExecutors")
     killExecutorPods(executorIds.map { id => (id, executorToPod(id)) })
-    // TODO: send shutdown message?  take off active list?  put onto waiting que and kill
-    // pods after graceful shutdown?
     Future.successful(true)
   }
 
@@ -100,12 +111,36 @@ private[spark] class KubernetesClusterSchedulerBackend(
     }
   }
 
+  def shutdownExecutors(idPodPairs: Seq[(String, String)]) {
+    val active = getExecutorIds.toSet
+
+    // Check for any finished shutting down and kill the pods
+    val shutdown = shutdownToPod.toVector.filter { case (e, _) => !active.contains(e) }
+    killExecutorPods(shutdown)
+
+    // Now request shutdown for the new ones.
+    // Move them from executor list to list pending shutdown
+    for ((id, pod) <- idPodPairs) {
+      try {
+        // TODO: 'ask' returns a future - can it be used to check eventual success?
+        Option(driverEndpoint).foreach(_.ask[Boolean](RemoveExecutor(id, ExecutorKilled)))
+        executorToPod -= id
+        shutdownToPod += ((id, pod))
+      } catch {
+        case e: Exception => logError(s"Error shutting down executor $id", e)
+      }
+    }
+  }
+
   private def killExecutorPods(idPodPairs: Seq[(String, String)]) {
-    for (kv <- idPodPairs) {
-      executorToPod -= kv._1
-      client.pods().inNamespace(ns).withName(kv._2).delete()
-      // TODO: send message to take off the active list?
-      // send shutdown message to executor back-end?
+    for ((id, pod) <- idPodPairs) {
+      try {
+        client.pods().inNamespace(ns).withName(pod).delete()
+        executorToPod -= id
+        shutdownToPod -= id
+      } catch {
+        case e: Exception => logError(s"Error killing executor pod $pod", e)
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds support for dynamic executors.  It works by running the shuffle server in the same container as the executor.

To use it, you will want to run with my latest image:
`manyangled/kube-spark:dynamic`

You must configure dynamic executors, for example submit using `--conf spark.dynamicAllocation.enabled=true`