### PR TITLE
Add/modify/delete ThirdPartyResources - Sequel

### DIFF
--- a/kubernetes/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/kubernetes/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -44,6 +44,7 @@ private[spark] class Client(val args: ClientArguments,
     scheduler.stop()
     shutdownLatch.countDown()
     System.clearProperty("SPARK_KUBERNETES_MODE")
+    System.clearProperty("SPARK_IMAGE_PULLSECRET")
   }
 
   def awaitShutdown(): Unit = {

--- a/kubernetes/src/main/scala/org/apache/spark/deploy/kubernetes/SparkJobResource.scala
+++ b/kubernetes/src/main/scala/org/apache/spark/deploy/kubernetes/SparkJobResource.scala
@@ -15,95 +15,142 @@
  * limitations under the License.
  */
 
-
 package org.apache.spark.deploy.kubernetes
-
-import java.util.concurrent.Executors
 
 import io.fabric8.kubernetes.client.{BaseClient, KubernetesClient}
 import okhttp3.{MediaType, OkHttpClient, Request, RequestBody}
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.cluster.kubernetes.JobState
+import org.apache.spark.scheduler.cluster.kubernetes.JobState._
+import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.json4s.JsonDSL._
+import org.json4s.jackson.Serialization.{read, write}
+
+ /**
+  * Representation of a Spark Job State in Kubernetes
+  */
+object SparkJobResource {
+   case class Metadata(name: String, uid: Option[String] = None,
+                       labels: Option[Map[String, String]] = None,
+                       annotations: Option[Map[String, String]] = None)
+
+   case class SparkJobState(apiVersion: String, kind: String,
+                            metadata: Metadata, spec: Map[String, Any])
+
+   case object JobStateSerDe extends CustomSerializer[JobState](format =>
+     ( {
+       case JString("SUBMITTED") => JobState.SUBMITTED
+       case JString("QUEUED") => JobState.QUEUED
+       case JString("RUNNING") => JobState.RUNNING
+       case JString("FINISHED") => JobState.FINISHED
+       case JString("KILLED") => JobState.KILLED
+       case JString("FAILED") => JobState.FAILED
+       case JNull => throw new UnsupportedOperationException("No JobState Specified")
+     }, {
+       case JobState.FAILED => JString("FAILED")
+       case JobState.SUBMITTED => JString("SUBMITTED")
+       case JobState.KILLED => JString("KILLED")
+       case JobState.FINISHED => JString("FINISHED")
+       case JobState.QUEUED => JString("QUEUED")
+       case JobState.RUNNING => JString("RUNNING")
+     })
+   )
+ }
 
 class SparkJobResource(client: KubernetesClient) extends Logging {
-  val ApiVersion = "apache.io/v1"
-  val Kind = "SparkJob"
 
-//  apiVersion: "apache.io/v1"
-//  kind: "SparkJob"
-//  metadata:
-//    name: "spark-job-1"
-//  spec:
-//    image: "driver-image"
-//    state: "completed"
-//    num-executors: 10
+  import SparkJobResource._
 
-  val httpClient = this.getHTTPClient(client.asInstanceOf[BaseClient])
-  def createJobObject(name: String, executors: Int, image: String): Unit = {
-    val json = ("apiVersion" -> ApiVersion) ~
-      ("kind" -> Kind) ~
-      ("metadata" -> ("name" -> name)) ~
-      ("spec" -> (("state" -> "started") ~
-          ("image" -> image) ~
-          ("num-executors" -> executors.toString)))
+  implicit val formats = DefaultFormats + JobStateSerDe
+  private val httpClient = getHttpClient(client.asInstanceOf[BaseClient])
+  private val kind = "SparkJob"
+  private val apiVersion = "apache.io/v1"
+  private val apiEndpoint = s"${client.getMasterUrl}/apis/$apiVersion/" +
+    s"namespaces/${client.getNamespace}/sparkjobs"
 
-    val body = RequestBody.create(MediaType.parse("application/json"), compact(render(json)))
-    logInfo(s"POSTing resource ${name}:" + pretty(render(json)))
-    val request = new Request.Builder()
-      .post(body)
-      .url(s"${client.getMasterUrl()}" +
-        s"apis/apache.io/v1/namespaces/default/sparkjobs/")
-      .build()
-    val response = httpClient.newCall(request).execute()
-    if (response.code() > 300) {
-      throw new SparkException("Unable to create SparkJob: " + response.body().string())
-    }
-  }
-
-  def deleteJobObject(name: String): Unit = {
-    logInfo(s"DELETEing resource ${name}")
-    val request = new Request.Builder()
-      .delete()
-      .url(s"${client.getMasterUrl()}" +
-        s"apis/apache.io/v1/namespaces/default/sparkjobs/${name}")
-      .build()
-    val response = httpClient.newCall(request).execute()
-    if (response.code() > 300) {
-      throw new SparkException("Unable to delete SparkJob: " + response.body().string())
-    }
-  }
-
-  def updateJobObject(name: String, field: String, value: String): Unit = {
-    val json = List(("op" -> "replace") ~ ("path" -> field) ~ ("value" -> value))
-    val body = RequestBody.create(MediaType.parse("application/json-patch+json"),
-      compact(render(json)))
-
-    logInfo(s"PATCHing resource ${name}:" + pretty(render(json)))
-    val request = new Request.Builder()
-      .patch(body)
-      .url(s"${client.getMasterUrl()}" +
-        s"apis/apache.io/v1/namespaces/default/sparkjobs/${name}")
-      .build()
-    val response = httpClient.newCall(request).execute()
-    if (response.code() > 300) {
-      throw new SparkException("Unable to patch SparkJob: " + response.body().string())
-    }
-  }
-
-  def findJobObject(): Unit = {
-    // TODO: implement logic to find things here.
-  }
-
-  def getHTTPClient(client: BaseClient): OkHttpClient = {
+  private def getHttpClient(client: BaseClient): OkHttpClient = {
     val field = classOf[BaseClient].getDeclaredField("httpClient")
     try {
       field.setAccessible(true)
-      return field.get(client).asInstanceOf[OkHttpClient]
+      field.get(client).asInstanceOf[OkHttpClient]
     } finally {
       field.setAccessible(false)
     }
   }
+
+  /*
+  * using a Map as an argument here allows adding more info into the Object if needed
+  * */
+  def createJobObject(name: String, keyValuePairs: Map[String, Any]): Unit = {
+    val resourceObject = SparkJobState(apiVersion, kind,
+      Metadata(name), keyValuePairs)
+    val payload = parse(write(resourceObject))
+    val requestBody = RequestBody.create(MediaType.parse("application/json"),
+      compact(render(payload)))
+    val request = new Request.Builder()
+      .post(requestBody)
+      .url(apiEndpoint)
+      .build()
+    val response = httpClient.newCall(request).execute()
+    if (response.code() == 201) {
+      logInfo(s"Successfully posted resource $name: " +
+        s"${pretty(render(parse(write(resourceObject))))}")
+    } else {
+      val msg = s"Failed to post resource $name. ${response.message()}"
+      logError(msg)
+      throw new SparkException(msg)
+    }
+  }
+
+  def updateJobObject(name: String, value: String, fieldPath: String): Unit = {
+    val payload = List(("op" -> "replace") ~ ("path" -> fieldPath) ~ ("value" -> value))
+    val requestBody = RequestBody.create(MediaType.parse("application/json-patch+json"),
+      compact(render(payload)))
+    val request = new Request.Builder()
+      .post(requestBody)
+      .url(s"$apiEndpoint/$name")
+      .build()
+    val response = httpClient.newCall(request).execute()
+    if (response.code() == 200) {
+      logInfo(s"Successfully patched resource $name")
+    } else {
+      val msg = s"Failed to patch resource $name. ${response.message()}"
+      logError(msg)
+      throw new SparkException(msg)
+    }
+  }
+
+  def deleteJobObject(name: String): Unit = {
+    val request = new Request.Builder()
+      .delete()
+      .url(s"$apiEndpoint/$name")
+      .build()
+    val response = httpClient.newCall(request).execute()
+    if (response.code() == 200) {
+      logInfo(s"Successfully deleted resource $name")
+    } else {
+      val msg = s"Failed to delete resource $name. ${response.message()}"
+      logError(msg)
+      throw new SparkException(msg)
+    }
+  }
+
+  def getJobObject(name: String): SparkJobState = {
+    val request = new Request.Builder()
+      .get()
+      .url(s"$apiEndpoint/$name")
+      .build()
+    val response = httpClient.newCall(request).execute()
+    if (response.code() == 200) {
+      logInfo(s"Successfully retrieved resource $name")
+      read[SparkJobState](response.body().string())
+    } else {
+      val msg = s"Failed to retrieve resource $name. ${response.message()}"
+      logError(msg)
+      throw new SparkException(msg)
+    }
+  }
+
 }

--- a/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/JobState.scala
+++ b/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/JobState.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.kubernetes
+
+private[spark] object JobState extends Enumeration {
+  type JobState = Value
+
+  /*
+   * QUEUED - Spark Job has been queued to run
+   * SUBMITTED - Driver Pod deployed but tasks are not yet scheduled on worker pod(s)
+   * RUNNING - Task(s) have been allocated to worker pod(s) to run and Spark Job is now running
+   * FINISHED - Spark Job ran and exited cleanly, i.e, worker pod(s) and driver pod were gracefully deleted
+   * FAILED - Spark Job Failed due to error
+   * KILLED - A user manually killed this Spark Job
+   */
+  val QUEUED, SUBMITTED, RUNNING, FINISHED, FAILED, KILLED = Value
+}

--- a/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterScheduler.scala
+++ b/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterScheduler.scala
@@ -21,8 +21,8 @@ import java.io.File
 import java.util.Date
 import java.util.concurrent.atomic.AtomicLong
 
-import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient, KubernetesClient}
-import io.fabric8.kubernetes.api.model.{PodBuilder, ServiceBuilder}
+import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient, KubernetesClient, KubernetesClientException}
+import io.fabric8.kubernetes.api.model.{Pod, PodBuilder, PodFluent, ServiceBuilder}
 import io.fabric8.kubernetes.client.dsl.LogWatch
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.kubernetes.ClientArguments
@@ -33,27 +33,29 @@ import org.apache.spark.internal.config._
 import collection.JavaConverters._
 import org.apache.spark.util.Utils
 
+import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 private[spark] object KubernetesClusterScheduler {
-  def defaultNameSpace = "default"
-  def defaultServiceAccountName = "default"
+  def defaultNameSpace: String = "default"
+  def defaultServiceAccountName: String = "default"
 }
 
+
 /**
-  * This is a simple extension to ClusterScheduler
-  * */
+ * This is a simple extension to ClusterScheduler
+ */
 private[spark] class KubernetesClusterScheduler(conf: SparkConf)
-    extends Logging {
+  extends Logging {
   private val DEFAULT_SUPERVISE = false
   private val DEFAULT_MEMORY = Utils.DEFAULT_DRIVER_MEM_MB // mb
   private val DEFAULT_CORES = 1.0
 
   logInfo("Created KubernetesClusterScheduler instance")
 
-  var client = setupKubernetesClient()
-  val driverName = s"spark-driver-${Random.alphanumeric take 5 mkString("")}".toLowerCase()
-  val svcName = s"spark-svc-${Random.alphanumeric take 5 mkString("")}".toLowerCase()
+  val client = setupKubernetesClient()
+  val driverName = s"spark-driver-${Random.alphanumeric take 5 mkString ""}".toLowerCase()
+  val svcName = s"spark-svc-${Random.alphanumeric take 5 mkString ""}".toLowerCase()
   val nameSpace = conf.get(
     "spark.kubernetes.namespace",
     KubernetesClusterScheduler.defaultNameSpace)
@@ -70,6 +72,19 @@ private[spark] class KubernetesClusterScheduler(conf: SparkConf)
     "spark.executor.jar",
     "spark.dynamicAllocation.enabled",
     "spark.shuffle.service.enabled")
+
+  val instances = conf.get(EXECUTOR_INSTANCES).getOrElse(1)
+
+  // image needs to support shim scripts "/opt/driver.sh" and "/opt/executor.sh"
+  private val sparkDriverImage = conf.getOption("spark.kubernetes.sparkImage").getOrElse {
+    // TODO: this needs to default to some standard Apache Spark image
+    throw new SparkException("Spark image not set. Please configure spark.kubernetes.sparkImage")
+  }
+
+  private val imagePullSecret = conf.get("spark.kubernetes.imagePullSecret", "")
+  private val isImagePullSecretSet = isSecretRunning(imagePullSecret)
+
+  logWarning("Instances: " +  instances)
 
   def start(args: ClientArguments): Unit = {
     startDriver(client, args)
@@ -88,12 +103,6 @@ private[spark] class KubernetesClusterScheduler(conf: SparkConf)
                   args: ClientArguments): Unit = {
     logInfo("Starting spark driver on kubernetes cluster")
     val driverDescription = buildDriverDescription(args)
-
-    // image needs to support shim scripts "/opt/driver.sh" and "/opt/executor.sh"
-    val sparkImage = conf.getOption("spark.kubernetes.sparkImage").getOrElse {
-      // TODO: this needs to default to some standard Apache Spark image
-      throw new SparkException("Spark image not set. Please configure spark.kubernetes.sparkImage")
-    }
 
     // This is the URL of the client jar.
     val clientJarUri = args.userJar
@@ -124,26 +133,11 @@ private[spark] class KubernetesClusterScheduler(conf: SparkConf)
       args.userArgs.mkString(" "))
 
     val labelMap = Map("type" -> "spark-driver")
-    val pod = new PodBuilder()
-      .withNewMetadata()
-      .withLabels(labelMap.asJava)
-      .withName(driverName)
-      .endMetadata()
-      .withNewSpec()
-      .withRestartPolicy("OnFailure")
-      .withServiceAccount(serviceAccountName)
-      .addNewContainer()
-      .withName("spark-driver")
-      .withImage(sparkImage)
-      .withImagePullPolicy("Always")
-      .withCommand(s"/opt/driver.sh")
-      .withArgs(submitArgs :_*)
-      .endContainer()
-      .endSpec()
-      .build()
+
+    val pod = buildPod(driverName, labelMap, submitArgs)
     client.pods().inNamespace(nameSpace).withName(driverName).create(pod)
 
-    var svc = new ServiceBuilder()
+    val svc = new ServiceBuilder()
       .withNewMetadata()
       .withLabels(labelMap.asJava)
       .withName(svcName)
@@ -166,19 +160,50 @@ private[spark] class KubernetesClusterScheduler(conf: SparkConf)
       .withName(svcName)
       .create(svc)
 
-//    try {
-//      while (true) {
-//        client
-//          .pods()
-//          .inNamespace("default")
-//          .withName("spark-driver")
-//          .tailingLines(10)
-//          .watchLog(System.out)
-//        Thread.sleep(5 * 1000)
-//      }
-//    } catch {
-//      case e: Exception => logError(e.getMessage)
-//    }
+  }
+
+   private def isSecretRunning(name: String): Boolean = {
+     if (name.isEmpty) {
+       false
+     } else {
+       // get() request could throw KubernetesClientException if an error occurs.
+       try {
+         client.secrets().inNamespace(nameSpace).withName(name).get() != null
+       } catch {
+         case e: KubernetesClientException => false
+           // is this enough to throw a SparkException? For now default to false
+       }
+     }
+   }
+
+  private def buildPod(podName: String, labelMap: Map[String, String],
+                       submitArgs: ArrayBuffer[String]) = {
+    val pod = new PodBuilder()
+      .withNewMetadata()
+      .withLabels(labelMap.asJava)
+      .withName(driverName)
+      .endMetadata()
+      .withNewSpec()
+      .withRestartPolicy("OnFailure")
+      .withServiceAccount(serviceAccountName)
+      .addNewContainer()
+      .withName("spark-driver")
+      .withImage(sparkDriverImage)
+      .withImagePullPolicy("Always")
+      .withCommand(s"/opt/driver.sh")
+      .withArgs(submitArgs: _*)
+      .endContainer()
+
+    buildPodUtil(pod)
+  }
+
+  private def buildPodUtil(pod: PodFluent.SpecNested[PodBuilder]): Pod = {
+    if (isImagePullSecretSet) {
+      System.setProperty("SPARK_IMAGE_PULLSECRET", imagePullSecret)
+      pod.addNewImagePullSecret(imagePullSecret).endSpec().build()
+    } else {
+      pod.endSpec().build()
+    }
   }
 
   def setupKubernetesClient(): KubernetesClient = {
@@ -222,7 +247,7 @@ private[spark] class KubernetesClusterScheduler(conf: SparkConf)
     val extraJavaOpts = driverExtraJavaOptions.map(Utils.splitCommandString).getOrElse(Seq.empty)
     val sparkJavaOpts = Utils.sparkJavaOpts(conf)
     val javaOpts = sparkJavaOpts ++ extraJavaOpts
-    val command = new Command(
+    val command = Command(
       mainClass, appArgs, null, extraClassPath, extraLibraryPath, javaOpts)
     val actualSuperviseDriver = superviseDriver.map(_.toBoolean).getOrElse(DEFAULT_SUPERVISE)
     val actualDriverMemory = driverMemory.map(Utils.memoryStringToMb).getOrElse(DEFAULT_MEMORY)

--- a/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/kubernetes/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.scheduler.cluster.kubernetes
 
 import collection.JavaConverters._
-import io.fabric8.kubernetes.api.model.PodBuilder
+import io.fabric8.kubernetes.api.model.{Pod, PodBuilder, PodFluent}
 import io.fabric8.kubernetes.api.model.extensions.JobBuilder
-import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
+import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient, KubernetesClientException}
 import org.apache.spark.deploy.kubernetes.SparkJobResource
 import org.apache.spark.internal.config._
 import org.apache.spark.scheduler._
@@ -31,25 +31,26 @@ import org.apache.spark.rpc.RpcEndpointAddress
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.util.Utils
 
-import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.{concurrent, mutable}
 import scala.util.Random
 import scala.concurrent.Future
 
 private[spark] class KubernetesClusterSchedulerBackend(
-                                                  scheduler: TaskSchedulerImpl,
-                                                  sc: SparkContext)
+                                                        scheduler: TaskSchedulerImpl,
+                                                        sc: SparkContext)
   extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv) {
 
-  val client = new DefaultKubernetesClient()
+  private val client = new DefaultKubernetesClient()
 
   val DEFAULT_NUMBER_EXECUTORS = 2
-  val podPrefix = s"spark-executor-${Random.alphanumeric take 5 mkString("")}".toLowerCase()
+  val podPrefix = s"spark-executor-${Random.alphanumeric take 5 mkString ""}".toLowerCase()
 
-  // TODO: do these need mutex guarding?
+  // using a concurrent TrieMap gets rid of possible concurrency issues
   // key is executor id, value is pod name
-  var executorToPod = mutable.Map.empty[String, String] // active executors
-  var shutdownToPod = mutable.Map.empty[String, String] // pending shutdown
-  var executorID = 0
+  private var executorToPod = new concurrent.TrieMap[String, String] // active executors
+  private var shutdownToPod = new concurrent.TrieMap[String, String] // pending shutdown
+  private var executorID = 0
 
   val sparkImage = conf.get("spark.kubernetes.sparkImage")
   val clientJarUri = conf.get("spark.executor.jar")
@@ -57,7 +58,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
     "spark.kubernetes.namespace",
     KubernetesClusterScheduler.defaultNameSpace)
   val dynamicExecutors = Utils.isDynamicAllocationEnabled(conf)
-  val sparkJobresource = new SparkJobResource(client)
+  val sparkJobResource = new SparkJobResource(client)
+
+  private val imagePullSecret = System.getProperty("SPARK_IMAGE_PULLSECRET", "")
 
   // executor back-ends take their configuration this way
   if (dynamicExecutors) {
@@ -67,8 +70,18 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   override def start(): Unit = {
     super.start()
-    sparkJobresource.createJobObject(podPrefix, getInitialTargetExecutorNumber(sc.getConf),
-      sparkImage)
+    val keyValuePairs = Map("num-executors" -> getInitialTargetExecutorNumber(sc.conf),
+      "image" -> sparkImage,
+      "state" -> JobState.SUBMITTED)
+    try {
+      logInfo(s"Creating Job Resource with name. $podPrefix")
+      sparkJobResource.createJobObject(podPrefix, keyValuePairs)
+    } catch {
+      case e: SparkException =>
+        logWarning(s"SparkJob object not created. ${e.getMessage}")
+      // SparkJob should continue if this fails as discussed on thread.
+      // TODO: we should short-circuit on things like update or delete
+    }
     createExecutorPods(getInitialTargetExecutorNumber(sc.getConf))
   }
 
@@ -76,7 +89,14 @@ private[spark] class KubernetesClusterSchedulerBackend(
     // Kill all executor pods indiscriminately
     killExecutorPods(executorToPod.toVector)
     killExecutorPods(shutdownToPod.toVector)
-    sparkJobresource.deleteJobObject(podPrefix)
+    // TODO: pods that failed during build up due to some error are left behind.
+    try{
+      sparkJobResource.deleteJobObject(podPrefix)
+    } catch {
+      case e: SparkException =>
+        logWarning(s"SparkJob object not deleted. ${e.getMessage}")
+      // what else do we need to do here ?
+    }
     super.stop()
   }
 
@@ -91,7 +111,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
     } else if (delta < 0) {
       val d = -delta
       val idle = executorToPod.toVector.filter { case (id, _) => !scheduler.isExecutorBusy(id) }
-      if (idle.length > 0) {
+      if (idle.nonEmpty) {
         logInfo(s"Shutting down ${idle.length} idle executors")
         shutdownExecutors(idle.take(d))
       }
@@ -103,7 +123,11 @@ private[spark] class KubernetesClusterSchedulerBackend(
     }
 
     // TODO: be smarter about when to update.
-    sparkJobresource.updateJobObject(podPrefix, "/spec/num-executors", requestedTotal.toString)
+    try {
+      sparkJobResource.updateJobObject(podPrefix, requestedTotal.toString, "/spec/num-executors")
+    } catch {
+      case e: SparkException => logWarning(s"SparkJob Object not updated. ${e.getMessage}")
+    }
     // TODO: are there meaningful failure modes here?
     Future.successful(true)
   }
@@ -150,6 +174,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
         shutdownToPod -= id
       } catch {
         case e: Exception => logError(s"Error killing executor pod $pod", e)
+          // TODO: we need some retry mechanism depending on the type of failure
       }
     }
   }
@@ -192,24 +217,37 @@ private[spark] class KubernetesClusterSchedulerBackend(
       "--app-id", "1", // TODO: change app-id per application and pass from driver.
       "--cores", "1")
 
-    var pod = new PodBuilder()
+    val pod = buildPod(labelMap, podName, submitArgs)
+    client.pods().inNamespace(ns).withName(podName).create(pod)
+    podName
+  }
+
+  private def buildPod(labelMap: Map[String, String], podName: String,
+                       submitArgs: ArrayBuffer[String]): Pod = {
+    val pod = new PodBuilder()
       .withNewMetadata()
       .withLabels(labelMap.asJava)
       .withName(podName)
       .endMetadata()
       .withNewSpec()
       .withRestartPolicy("OnFailure")
-
-      .addNewContainer().withName("spark-executor").withImage(sparkImage)
+      .addNewContainer()
+      .withName("spark-executor")
+      .withImage(sparkImage)
       .withImagePullPolicy("IfNotPresent")
       .withCommand("/opt/executor.sh")
-      .withArgs(submitArgs :_*)
+      .withArgs(submitArgs: _*)
       .endContainer()
 
-      .endSpec().build()
-    client.pods().inNamespace(ns).withName(podName).create(pod)
+    buildPodUtil(pod)
+  }
 
-    podName
+  private def buildPodUtil(pod: PodFluent.SpecNested[PodBuilder]): Pod = {
+    if (imagePullSecret.nonEmpty) {
+      pod.addNewImagePullSecret(imagePullSecret).endSpec().build()
+    } else {
+      pod.endSpec().build()
+    }
   }
 
   protected def driverURL: String = {
@@ -223,8 +261,5 @@ private[spark] class KubernetesClusterSchedulerBackend(
     }
   }
 
-  override def getDriverLogUrls: Option[Map[String, String]] = {
-    var driverLogs: Option[Map[String, String]] = None
-    driverLogs
-  }
+  override def getDriverLogUrls: Option[Map[String, String]] = None
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- SparkJobState representation as a case class, making it easy to serialize, deserialize to and from json respectively
- Implements POST/PATCH/DELETE/GET for the SparkJob TPR based on the case-class representation.
- Representation of JobState as an Enum type
- Support for ImagePullSecrets in the case where image is pulled from a private registry. Set `spark.kubernetes.imagePullSecret` to use with secret

I have rebased my commit to the tip of this branch, so it should be trivial to merge.