### PR TITLE
Use tar and gzip to compress+archive shipped jars.

### DIFF
--- a/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -35,7 +35,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Success
 
 import org.apache.spark.{SPARK_VERSION, SparkConf}
-import org.apache.spark.deploy.rest.{AppResource, KubernetesCreateSubmissionRequest, RemoteAppResource, UploadedAppResource}
+import org.apache.spark.deploy.rest.{AppResource, KubernetesCreateSubmissionRequest, RemoteAppResource, TarGzippedData, UploadedAppResource}
 import org.apache.spark.deploy.rest.kubernetes._
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
@@ -275,8 +275,8 @@ private[spark] class Client(
       case other => RemoteAppResource(other)
     }
 
-    val uploadDriverExtraClasspathBase64Contents = getFileContents(uploadedDriverExtraClasspath)
-    val uploadJarsBase64Contents = getFileContents(uploadedJars)
+    val uploadDriverExtraClasspathBase64Contents = compressJars(uploadedDriverExtraClasspath)
+    val uploadJarsBase64Contents = compressJars(uploadedJars)
     KubernetesCreateSubmissionRequest(
       appResource = resolvedAppResource,
       mainClass = mainClass,
@@ -287,19 +287,10 @@ private[spark] class Client(
       uploadedJarsBase64Contents = uploadJarsBase64Contents)
   }
 
-  def getFileContents(maybeFilePaths: Option[String]): Array[(String, String)] = {
+  def compressJars(maybeFilePaths: Option[String]): Option[TarGzippedData] = {
     maybeFilePaths
-      .map(_.split(",").map(filePath => {
-        val fileToUpload = new File(filePath)
-        if (!fileToUpload.isFile) {
-          throw new IllegalStateException("Provided file to upload for driver extra classpath" +
-            s" does not exist or is not a file: $filePath")
-        } else {
-          val fileBytes = Files.toByteArray(fileToUpload)
-          val fileBase64 = Base64.encodeBase64String(fileBytes)
-          (fileToUpload.getName, fileBase64)
-        }
-      })).getOrElse(Array.empty[(String, String)])
+      .map(_.split(","))
+      .map(CompressionUtils.createTarGzip(_))
   }
 
   private def getDriverLauncherService(

--- a/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/KubernetesRestProtocolMessages.scala
+++ b/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/KubernetesRestProtocolMessages.scala
@@ -27,13 +27,18 @@ case class KubernetesCreateSubmissionRequest(
   val appArgs: Array[String],
   val sparkProperties: Map[String, String],
   val secret: String,
-  val uploadedDriverExtraClasspathBase64Contents: Array[(String, String)]
-      = Array.empty[(String, String)],
-  val uploadedJarsBase64Contents: Array[(String, String)]
-      = Array.empty[(String, String)]) extends SubmitRestProtocolRequest {
+  val uploadedDriverExtraClasspathBase64Contents: Option[TarGzippedData],
+  val uploadedJarsBase64Contents: Option[TarGzippedData]) extends SubmitRestProtocolRequest {
   message = "create"
   clientSparkVersion = SPARK_VERSION
 }
+
+case class TarGzippedData(
+  val dataBase64: String,
+  val blockSize: Int = 10240,
+  val recordSize: Int = 512,
+  val encoding: String
+)
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,

--- a/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/CompressionUtils.scala
+++ b/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/CompressionUtils.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.rest.kubernetes
+
+import java.io.{ByteArrayInputStream, File, FileInputStream, FileOutputStream}
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
+
+import com.google.common.io.Files
+import org.apache.commons.codec.binary.Base64
+import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveInputStream, TarArchiveOutputStream}
+import org.apache.commons.compress.utils.CharsetNames
+import org.apache.commons.io.IOUtils
+import scala.collection.mutable
+
+import org.apache.spark.deploy.rest.TarGzippedData
+import org.apache.spark.util.{ByteBufferOutputStream, Utils}
+
+private[spark] object CompressionUtils {
+  private val BLOCK_SIZE = 10240
+  private val RECORD_SIZE = 512
+  private val ENCODING = CharsetNames.UTF_8
+
+  def createTarGzip(paths: Iterable[String]): TarGzippedData = {
+    val compressedBytesStream = Utils.tryWithResource(new ByteBufferOutputStream()) { raw =>
+      Utils.tryWithResource(new GZIPOutputStream(raw)) { gzipping =>
+        Utils.tryWithResource(new TarArchiveOutputStream(
+            gzipping,
+            BLOCK_SIZE,
+            RECORD_SIZE,
+            ENCODING)) { tarStream =>
+          val usedFileNames = mutable.HashSet.empty[String]
+          for (path <- paths) {
+            val file = new File(path)
+            if (!file.isFile) {
+              throw new IllegalArgumentException(s"Cannot add $path to tarball; either does" +
+                s" not exist or is a directory.")
+            }
+            var resolvedFileName = file.getName
+            val extension = Files.getFileExtension(file.getName)
+            val nameWithoutExtension = Files.getNameWithoutExtension(file.getName)
+            var deduplicationCounter = 1
+            while (usedFileNames.contains(resolvedFileName)) {
+              resolvedFileName = s"$nameWithoutExtension-$deduplicationCounter.$extension"
+              deduplicationCounter += 1
+            }
+            usedFileNames += resolvedFileName
+            val tarEntry = new TarArchiveEntry(file, resolvedFileName)
+            tarStream.putArchiveEntry(tarEntry)
+            Utils.tryWithResource(new FileInputStream(file)) { fileInput =>
+              IOUtils.copy(fileInput, tarStream)
+            }
+            tarStream.closeArchiveEntry()
+          }
+        }
+      }
+      raw
+    }
+    val compressedAsBase64 = Base64.encodeBase64String(compressedBytesStream.toByteBuffer.array)
+    TarGzippedData(
+      dataBase64 = compressedAsBase64,
+      blockSize = BLOCK_SIZE,
+      recordSize = RECORD_SIZE,
+      encoding = ENCODING
+    )
+  }
+
+  def unpackAndWriteCompressedFiles(
+      compressedData: TarGzippedData,
+      rootOutputDir: File): Seq[String] = {
+    val paths = mutable.Buffer.empty[String]
+    val compressedBytes = Base64.decodeBase64(compressedData.dataBase64)
+    if (!rootOutputDir.exists) {
+      rootOutputDir.mkdir
+    } else if (rootOutputDir.isFile) {
+      throw new IllegalArgumentException(s"Root dir for writing decompressed files: " +
+         s"${rootOutputDir.getAbsolutePath} exists and is not a directory.")
+    }
+    Utils.tryWithResource(new ByteArrayInputStream(compressedBytes)) { compressedBytesStream =>
+      Utils.tryWithResource(new GZIPInputStream(compressedBytesStream)) { gzipped =>
+        Utils.tryWithResource(new TarArchiveInputStream(
+            gzipped,
+            compressedData.blockSize,
+            compressedData.recordSize,
+            compressedData.encoding)) { tarInputStream =>
+          var nextTarEntry = tarInputStream.getNextTarEntry
+          while (nextTarEntry != null) {
+            val outputFile = new File(rootOutputDir, nextTarEntry.getName)
+            Utils.tryWithResource(new FileOutputStream(outputFile)) { fileOutputStream =>
+              IOUtils.copy(tarInputStream, fileOutputStream)
+            }
+            paths += outputFile.getAbsolutePath
+            nextTarEntry = tarInputStream.getNextTarEntry
+          }
+        }
+      }
+    }
+    paths.toSeq
+  }
+}

--- a/kubernetes/integration-tests-spark-jobs-helpers/pom.xml
+++ b/kubernetes/integration-tests-spark-jobs-helpers/pom.xml
@@ -24,28 +24,10 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-kubernetes-integration-tests-spark-jobs_2.11</artifactId>
+  <artifactId>spark-kubernetes-integration-tests-spark-jobs-helpers_2.11</artifactId>
   <packaging>jar</packaging>
-  <name>Spark Project Kubernetes Integration Tests Spark Jobs</name>
+  <name>Spark Project Kubernetes Integration Tests Spark Jobs Helpers</name>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-kubernetes-integration-tests-spark-jobs-helpers_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/kubernetes/integration-tests-spark-jobs-helpers/src/main/java/org/apache/spark/deploy/kubernetes/integrationtest/PiHelper.java
+++ b/kubernetes/integration-tests-spark-jobs-helpers/src/main/java/org/apache/spark/deploy/kubernetes/integrationtest/PiHelper.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.integrationtest;
+
+public class PiHelper {
+  public static int helpPi() {
+    double x = Math.random() * 2 - 1;
+    double y = Math.random() * 2 - 1;
+    if (x*x + y*y < 1) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/kubernetes/integration-tests-spark-jobs/src/main/scala/org/apache/spark/deploy/kubernetes/integrationtest/jobs/SparkPiWithInfiniteWait.scala
+++ b/kubernetes/integration-tests-spark-jobs/src/main/scala/org/apache/spark/deploy/kubernetes/integrationtest/jobs/SparkPiWithInfiniteWait.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.spark.deploy.kubernetes.integrationtest.jobs
 
-import scala.math.random
-
+import org.apache.spark.deploy.kubernetes.integrationtest.PiHelper
 import org.apache.spark.sql.SparkSession
 
 // Equivalent to SparkPi except does not stop the Spark Context
@@ -32,10 +31,8 @@ private[spark] object SparkPiWithInfiniteWait {
       .getOrCreate()
     val slices = if (args.length > 0) args(0).toInt else 10
     val n = math.min(100000L * slices, Int.MaxValue).toInt // avoid overflow
-    val count = spark.sparkContext.parallelize(1 until n, slices).map { i =>
-        val x = random * 2 - 1
-        val y = random * 2 - 1
-        if (x*x + y*y < 1) 1 else 0
+    val count = spark.sparkContext.parallelize(1 until n, slices).map { _ =>
+        PiHelper.helpPi()
       }.reduce(_ + _)
     // scalastyle:off println
     println("Pi is roughly " + 4.0 * count / (n - 1))

--- a/kubernetes/integration-tests/pom.xml
+++ b/kubernetes/integration-tests/pom.xml
@@ -50,6 +50,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-kubernetes-integration-tests-spark-jobs-helpers_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-docker-minimal-bundle_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>tar.gz</type>
@@ -122,6 +128,13 @@
                   <version>${project.version}</version>
                   <type>jar</type>
                   <outputDirectory>${project.build.directory}/integration-tests-spark-jobs</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.spark</groupId>
+                  <artifactId>spark-kubernetes-integration-tests-spark-jobs-helpers_${scala.binary.version}</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>${project.build.directory}/integration-tests-spark-jobs-helpers</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
+++ b/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
@@ -41,6 +41,11 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
       .listFiles()(0)
       .getAbsolutePath
 
+  private val HELPER_JAR = Paths.get("target", "integration-tests-spark-jobs-helpers")
+      .toFile
+      .listFiles()(0)
+      .getAbsolutePath
+
   private val TIMEOUT = PatienceConfiguration.Timeout(Span(2, Minutes))
   private val INTERVAL = PatienceConfiguration.Interval(Span(2, Seconds))
   private val MAIN_CLASS = "org.apache.spark.deploy.kubernetes" +
@@ -118,6 +123,7 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
       .set("spark.kubernetes.namespace", NAMESPACE)
       .set("spark.kubernetes.driver.docker.image", "spark-driver:latest")
       .set("spark.kubernetes.executor.docker.image", "spark-executor:latest")
+      .set("spark.kubernetes.driver.uploads.jars", HELPER_JAR)
       .set("spark.executor.memory", "500m")
       .set("spark.executor.cores", "1")
       .set("spark.executors.instances", "1")
@@ -144,6 +150,7 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
       "--executor-memory", "512m",
       "--executor-cores", "1",
       "--num-executors", "1",
+      "--upload-jars", HELPER_JAR,
       "--class", MAIN_CLASS,
       "--conf", s"spark.kubernetes.submit.caCertFile=${clientConfig.getCaCertFile}",
       "--conf", s"spark.kubernetes.submit.clientKeyFile=${clientConfig.getClientKeyFile}",

--- a/pom.xml
+++ b/pom.xml
@@ -2638,6 +2638,7 @@
         <module>kubernetes/docker-minimal-bundle</module>
         <module>kubernetes/integration-tests</module>
         <module>kubernetes/integration-tests-spark-jobs</module>
+        <module>kubernetes/integration-tests-spark-jobs-helpers</module>
       </modules>  
     </profile>
 


### PR DESCRIPTION
Compresses the user's jar uploads before they are sent over the wire. Note that while gzipping is the important part to compress things, there could be multiple possible choices over tar as the format for indicating "boundaries" between items in the stream. Encoding the file names is tricky to do by hand however so being able to get this for free using tar is helpful.